### PR TITLE
Update README.md to reflect current features and usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,36 +1,39 @@
 # b2c-migrator
 
-A command-line tool written in Rust to migrate user data from a CSV file to a target API endpoint. It's designed to be robust, handling API rate limits and providing detailed logging.
+A command-line tool written in Rust to migrate user data from a CSV file to a target API endpoint. It's designed to be robust, handling API rate limits, providing detailed logging, and offering flexible configuration through command-line arguments.
 
 ## Core Features
 
-*   **CSV Input:** Reads user data from a CSV file (default: `data.csv`).
-*   **Asynchronous API Calls:** Makes asynchronous HTTP POST requests to a configurable API endpoint.
+*   **CSV Input:** Reads user data from a user-specified CSV file.
+*   **Command-line Configuration:** Utilizes `clap` for easy configuration of API token, data file path, and concurrency level.
+*   **Asynchronous API Calls:** Makes asynchronous HTTP POST requests to the target API endpoint.
 *   **Rate Limit Handling:** Intelligently handles HTTP 429 "Too Many Requests" responses by respecting the `Retry-After` header.
-*   **Concurrency Management:** Uses a semaphore to control the maximum number of concurrent requests, preventing server overload.
+*   **Concurrency Management:** Uses a semaphore to control the maximum number of concurrent requests, configurable via a command-line argument.
 *   **Comprehensive Logging:** Provides structured logging to:
     *   `stdout` (console) with colored severity levels.
     *   A local file (`output.log`).
-    *   An SQLite database (`logs.db`) with timestamped tables for each run.
+    *   An SQLite database (`logs.db`) with dynamically named tables for each run (e.g., `YYYYMMDDHHMMSS`), including parsed usernames in log entries.
 *   **Flexible Data Mapping:** Maps CSV data to JSON request bodies. Explicit fields like `displayName`, `passwordProfile`, and `identities` are handled directly, while any other CSV columns are collected as custom fields in the JSON payload.
 
 ## Prerequisites
 
 *   **Rust:** Ensure you have a recent version of Rust installed (compiles with Rust 2021 edition). You can find installation instructions at [https://www.rust-lang.org/tools/install](https://www.rust-lang.org/tools/install).
-*   **Input CSV File:** A CSV file containing the user data. By default, the application looks for `data.csv` in its root directory.
+*   **Input CSV File:** A CSV file containing the user data, specified via a command-line argument.
 
 ## Configuration
 
-Currently, primary configuration parameters are hardcoded in `src/main.rs`:
+The application is configured via command-line arguments:
 
-*   `max_concurrent_requests`: (Default: `4`) Maximum concurrent HTTP requests.
-*   `endpoint`: (Default: `"https://rullo.free.beeceptor.com"`) Target API endpoint URL.
-*   `file_path`: (Default: `"data.csv"`) Path to the input CSV file.
-*   Log files: `output.log` (text log) and `logs.db` (SQLite log) are generated in the root directory.
+*   **API Endpoint:** The target API endpoint is currently fixed to `https://frillo.free.beeceptor.com` in `src/main.rs`.
+*   **Log files:** `output.log` (text log) and `logs.db` (SQLite log) are generated in the root directory.
 
-Modifying these requires editing `src/main.rs` and recompiling.
+**Command-line Arguments:**
 
-## Input CSV Format (`data.csv`)
+*   `-t, --token <TOKEN>`: **Required**. Sets the Bearer token used for authentication with the API.
+*   `-d, --data <FILE_PATH>`: **Required**. Sets the path to the input CSV data file.
+*   `-n, --threads <NUMBER>`: Optional. Sets the number of concurrent threads (requests) to use. Defaults to `4`.
+
+## Input CSV Format
 
 The application processes each row of the CSV file to construct a JSON payload for the target API. The CSV column headers become keys in the JSON object.
 
@@ -59,7 +62,7 @@ displayName,passwordProfile,identities,accountEnabled,mailNickname,userPrincipal
     git clone <repository-url>
     cd b2c-migrator
     ```
-2.  **Prepare your input file:** Ensure your `data.csv` (or the CSV file you configure in `src/main.rs`) is in the project's root directory.
+2.  **Prepare your input file:** Ensure your CSV data file is accessible and you have its path.
 3.  **Build the project:**
     ```bash
     cargo build
@@ -69,13 +72,19 @@ displayName,passwordProfile,identities,accountEnabled,mailNickname,userPrincipal
     cargo build --release
     ```
 4.  **Run the application:**
-    From the project root:
+    From the project root, you must provide the token and data file path. You can optionally specify the number of threads.
+
+    Using `cargo run`:
     ```bash
-    cargo run
+    cargo run -- --token "YOUR_API_TOKEN" --data "path/to/your/data.csv"
+    ```
+    With a specific number of threads:
+    ```bash
+    cargo run -- --token "YOUR_API_TOKEN" --data "path/to/your/data.csv" --threads 8
     ```
     If you built a release version, the executable is in `target/release/`:
     ```bash
-    ./target/release/b2c-migrator
+    ./target/release/b2c-migrator --token "YOUR_API_TOKEN" --data "path/to/your/data.csv"
     ```
 
 ## Logging & Error Handling
@@ -83,12 +92,12 @@ displayName,passwordProfile,identities,accountEnabled,mailNickname,userPrincipal
 The application provides detailed logging:
 *   **Console (stdout):** Real-time logs with color-coded severity.
 *   **File (`output.log`):** All log messages are saved for review.
-*   **SQLite (`logs.db`):** Structured logs are stored in a new table (named with current timestamp) for each run, allowing for easier querying and analysis. User-specific log messages include the `issuerAssignedId` for traceability.
+*   **SQLite (`logs.db`):** Structured logs are stored in a new table for each run, named with the current timestamp (e.g., `20231027153000`). User-specific log messages include the `issuerAssignedId` (parsed as username) for traceability.
 
 **Error Handling:**
-*   Critical errors during setup (e.g., cannot open `data.csv`, database issues) will cause the program to terminate and print an error message to `stderr`.
+*   Critical errors during setup (e.g., cannot open the specified CSV data file, database issues) will cause the program to terminate and print an error message to `stderr`.
 *   Errors related to processing individual user records (e.g., API call failures for a specific user, invalid data for a user) are logged with `ERROR` severity, but the application will continue processing other records.
-*   HTTP 429 "Too Many Requests" errors are handled by pausing and retrying according to the `Retry-After` header. If the header is missing or invalid for a 429 response, the task for that user will be aborted after logging an error.
+*   HTTP 429 "Too Many Requests" errors are handled by pausing and retrying according to the `Retry-After` header. If the `Retry-After` header is missing or invalid for a 429 response, the task for that specific user will be aborted after logging an error, and the application will move on to the next user.
 
 ## Dependencies
 
@@ -101,15 +110,30 @@ This project relies on several key Rust crates:
 *   **`log` & `fern`**: For flexible and structured logging.
 *   **`chrono`**: For timestamping log entries.
 *   **`rusqlite`**: For SQLite database interaction (logging).
+*   **`clap`**: For parsing command-line arguments.
+*   **`indicatif`**: For displaying progress bars.
+
+## Testing
+
+The project includes unit and integration tests to help ensure reliability and correctness.
+
+*   **Unit tests for data structures:** Located in `src/graph/user.rs`, these tests verify the custom deserialization logic for `passwordProfile` and `identities` fields.
+*   **Unit tests for logging:** Located in `src/main.rs`, these tests verify the functionality of the `DBLogger`, ensuring log messages are correctly parsed and stored in the SQLite database.
+*   **Integration tests for API calls:** Also in `src/main.rs`, these tests use `mockito` to simulate an HTTP server and verify the behavior of `make_async_rest_call`, including success cases, rate limit handling (429 errors with `Retry-After`), and other error scenarios.
+
+To run all tests:
+```bash
+cargo test
+```
 
 ## Future Enhancements
 
 Potential areas for future development include:
 
-*   **Dynamic Configuration:** Allow `endpoint`, `file_path`, `max_concurrent_requests`, and log settings to be configured via command-line arguments or environment variables instead of hardcoding.
-*   **Enhanced Error Reporting:** Provide summaries of successful/failed migrations at the end of the run.
-*   **Test Suite:** Develop unit and integration tests to ensure reliability.
-*   **Input Validation:** More granular validation of CSV data before attempting API calls.
+*   **Configuration File/Environment Variables:** Allow API endpoint and other less frequently changed settings to be configured via a file or environment variables, in addition to command-line arguments.
+*   **Enhanced Error Reporting:** Provide summaries of successful/failed migrations at the end of the run, possibly with counts and lists of problematic `issuerAssignedId`s.
+*   **Input Validation:** More granular validation of CSV data (e.g., specific formats for certain fields) before attempting API calls.
+*   **Dry Run Mode:** Implement a mode to simulate the migration without making actual API calls, useful for validating data and configurations.
 
 ---
 


### PR DESCRIPTION
- Document command-line arguments for token, data file, and threads.
- Correct API endpoint information.
- Update instructions for running the application.
- Detail improvements in logging (dynamic SQLite table names, username parsing).
- Add a new section on testing and how to run tests.
- List `clap` and `indicatif` as dependencies.
- Revise 'Future Enhancements' section.